### PR TITLE
Add optional targets argument to CNVkit

### DIFF
--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,7 +114,6 @@ If you are running the pipeline to generate references for the GATK's germlinecn
 
 <sup>1</sup> To learn more about this file, see [this comment](https://gatk.broadinstitute.org/hc/en-us/community/posts/360074399831/comments/13441240230299) on GATK forum.<br />
 
-
 ### cnvkit
 
 If you are running the pipeline to generate references for the CNVkit variant calling workflow, you should consider that currently the default method for this pipeline is whole-genome. In order to use the CNVkit default, i.e. hybrid capture, when the user is creating a background for targeted capture sequencing (most commonly, exomes or panels), the user should
@@ -132,8 +131,6 @@ process {
 ```
 
 2. provide the `--cnvkit_target` parameter (optional) as a .bed file for the targets
-
-
 
 ## Core Nextflow arguments
 

--- a/docs/usage.md
+++ b/docs/usage.md
@@ -114,6 +114,27 @@ If you are running the pipeline to generate references for the GATK's germlinecn
 
 <sup>1</sup> To learn more about this file, see [this comment](https://gatk.broadinstitute.org/hc/en-us/community/posts/360074399831/comments/13441240230299) on GATK forum.<br />
 
+
+### cnvkit
+
+If you are running the pipeline to generate references for the CNVkit variant calling workflow, you should consider that currently the default method for this pipeline is whole-genome. In order to use the CNVkit default, i.e. hybrid capture, when the user is creating a background for targeted capture sequencing (most commonly, exomes or panels), the user should
+
+1. provide an additional config file, in order to change or remove the method specified in the default `ext.args`, i.e.
+
+```
+process {
+
+    withName: CNVKIT_BATCH {
+        ext.args   = {"--output-reference ${meta.id}.cnn"}
+    }
+
+}
+```
+
+2. provide the `--cnvkit_target` parameter (optional) as a .bed file for the targets
+
+
+
 ## Core Nextflow arguments
 
 > **NB:** These options are part of Nextflow and use a _single_ hyphen (pipeline parameters use a double-hyphen).

--- a/nextflow.config
+++ b/nextflow.config
@@ -28,6 +28,9 @@ params {
     scatter_content            = 5000
     segmental_duplications     = null
 
+    // CNVkit options
+    cnvkit_targets             = null
+
     // MultiQC options
     multiqc_config             = null
     multiqc_title              = null

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -66,6 +66,17 @@
                 }
             }
         },
+        "cnvkit_options": {
+            "title": "CNVkit options",
+            "type": "object",
+            "description": "Options used by the cnvkit subworkflow",
+            "default": "",
+            "properties": {
+                "cnvkit_targets": {
+                    "type": "string"
+                }
+            }
+        },
         "input_output_options": {
             "title": "Input/output options",
             "type": "object",
@@ -383,6 +394,9 @@
     "allOf": [
         {
             "$ref": "#/definitions/germlinecnvcaller_options"
+        },
+        {
+            "$ref": "#/definitions/cnvkit_options"
         },
         {
             "$ref": "#/definitions/input_output_options"

--- a/workflows/createpanelrefs.nf
+++ b/workflows/createpanelrefs.nf
@@ -52,7 +52,7 @@ ch_fasta          = params.fasta          ? Channel.fromPath(params.fasta).map {
 ch_ploidy_priors  = params.ploidy_priors  ? Channel.fromPath(params.ploidy_priors).collect()
                                             : Channel.empty()
 ch_cnvkit_targets = params.cnvkit_targets ? Channel.fromPath(params.cnvkit_targets).map { targets -> [[id:targets.baseName],targets]}.collect()
-                                            : Channel.empty()
+                                            : Channel.value([[:],[]])
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/workflows/createpanelrefs.nf
+++ b/workflows/createpanelrefs.nf
@@ -43,14 +43,16 @@ ch_input = ch_from_samplesheet.map{meta, bam, bai, cram, crai ->
 }
 
 // Initialize file channels based on params, defined in the params.genomes[params.genome] scope
-ch_dict          = params.dict          ? Channel.fromPath(params.dict).map { dict -> [[id:dict.baseName],dict]}.collect()
-                                        : Channel.empty()
-ch_fai           = params.fai           ? Channel.fromPath(params.fai).map { fai -> [[id:fai.baseName],fai]}.collect()
-                                        : Channel.empty()
-ch_fasta         = params.fasta         ? Channel.fromPath(params.fasta).map { fasta -> [[id:fasta.baseName],fasta]}.collect()
-                                        : Channel.empty()
-ch_ploidy_priors = params.ploidy_priors ? Channel.fromPath(params.ploidy_priors).collect()
-                                        : Channel.empty()
+ch_dict           = params.dict           ? Channel.fromPath(params.dict).map { dict -> [[id:dict.baseName],dict]}.collect()
+                                            : Channel.empty()
+ch_fai            = params.fai            ? Channel.fromPath(params.fai).map { fai -> [[id:fai.baseName],fai]}.collect()
+                                            : Channel.empty()
+ch_fasta          = params.fasta          ? Channel.fromPath(params.fasta).map { fasta -> [[id:fasta.baseName],fasta]}.collect()
+                                            : Channel.empty()
+ch_ploidy_priors  = params.ploidy_priors  ? Channel.fromPath(params.ploidy_priors).collect()
+                                            : Channel.empty()
+ch_cnvkit_targets = params.cnvkit_targets ? Channel.fromPath(params.cnvkit_targets).map { targets -> [[id:targets.baseName],targets]}.collect()
+                                            : Channel.empty()
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -117,7 +119,7 @@ workflow CREATEPANELREFS {
         .map {meta, bam -> [ meta, [], bam ]}
         .set { ch_cnvkit_input }
 
-        CNVKIT_BATCH ( ch_cnvkit_input, ch_fasta, [[:],[]], [[:],[]], [[:],[]], true )
+        CNVKIT_BATCH ( ch_cnvkit_input, ch_fasta, [[:],[]], ch_cnvkit_targets, [[:],[]], true )
         ch_versions = ch_versions.mix(CNVKIT_BATCH.out.versions)
     }
 


### PR DESCRIPTION
## PR checklist

- [ ] Reasons:
The current version of this tool defaults to the WGS method and has no option to pass the necessary target intervals for either hybrid method (which would be default of CNVkit) or amplicon method.
This PR simply adds a `cnvkit_targets` parameter, which can be used if the user wishes to default to the hybrid method. The channel defaults to the usual empty tuple, should the targets bed file not be provided, leaving the current execution as is.
- [ ] If you've fixed a bug or added code that should be tested, add tests!
The modified pipeline has been successfully tested on real-life data, with either hybrid or current WGS method.
- [ ] No new data were needed for this change
- [ ] Make sure your code lints (`nf-core lint`): current version of dev - please note that some lint failures occur due to mismatch in template
- [ ] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [ ] Usage Documentation in `docs/usage.md` has been updated to explain the necessary modification of config file as well as the new optional parameter usage.
- [ ] Output Documentation in `docs/output.md` is updated.
- [ ] `CHANGELOG.md` is updated.
- [ ] `README.md` is updated (including new tool citations and authors/contributors).
