### PR TITLE
fix gcnv interval list

### DIFF
--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -244,7 +244,7 @@
                     "exists": true,
                     "format": "path",
                     "fa_icon": "fas fa-file",
-                    "pattern": "^\\S+\\._interval_list$",
+                    "pattern": "^\\S+\\.interval_list$",
                     "description": "Path to directory for exclude_interval_list file.",
                     "help_text": "If the regions you would like to exclude are in interval_list format, use this option. If you have a bed file, use `exclude` parameter instead."
                 },
@@ -287,7 +287,7 @@
                     "exists": true,
                     "format": "path",
                     "fa_icon": "fas fa-file",
-                    "pattern": "^\\S+\\._interval_list$",
+                    "pattern": "^\\S+\\.interval_list$",
                     "description": "Path to directory for target interval_list file.",
                     "help_text": "If the regions you would like to analyse are in interval_list format, use this option. If you have a bed file, use `target_bed` parameter instead."
                 },


### PR DESCRIPTION
When using the ._interval_list file extension, the gatk PreprocessIntervals fails.
Error meessage:
```
  ***********************************************************************
  
  A USER ERROR has occurred: Couldn't read file file._interval_list. Error was: The file file._interval_list exists, but does not contain Features (ie., is not in a supported Feature file format such as vcf, bcf, bed, or interval_list), and does not have one of the supported interval file extensions ([.list, .intervals]). Please rename your file with the appropriate extension. If file._interval_list is NOT supposed to be a file, please move or rename the file at location file._interval_list
  
  ***********************************************************************
```
After updating the nextflow schema to .interval_list the process completed successfully.

`  gcnv_target_interval_list          : path/to/file.interval_list`

```
executor >  slurm (46)
[-        ] PRE…4_CREATESEQUENCEDICTIONARY -
[-        ] PREPARE_GENOME:SAMTOOLS_FAIDX  -
[-        ] PRE…4_PREPROCESSINTERVALS_GENS -
[-        ] PREPARE_GENOME:BUILD_INTERVALS -
[-        ] NFC…DEXFEATUREFILE_MAPPABILITY -
[-        ] NFC…K4_INDEXFEATUREFILE_SEGDUP -
[-        ] NFC…_BEDTOINTERVALLIST_TARGETS -
[-        ] NFC…_BEDTOINTERVALLIST_EXCLUDE -
[32/8b6ea7] NFC…8.dna.primary_assembly.fa) | 1 of 1 ✔
[1a/c1df13] NFC…ANNOTATEINTERVALS (genome) | 1 of 1 ✔
[-        ] NFC…LLER_COHORT:SAMTOOLS_INDEX -
[44/035268] NFC…OLLECTREADCOUNTS (S6715.2) | 3 of 3 ✔
[b0/c91a1f] NFC…4_FILTERINTERVALS (genome) | 1 of 1 ✔
[f0/a3bc78] NFC…INTERVALLISTTOOLS (genome) | 1 of 1 ✔
[c3/6b7b5c] NFC…PLOIDY (germlinecnvcaller) | 1 of 1 ✔
[f1/0ea2df] NFC…INECNVCALLER (17scattered) | 45 of 45 ✔
[ee/4274e0] MULTIQC                        | 1 of 1 ✔
-[nf-core/createpanelrefs] Pipeline completed successfully-


```

## PR checklist

- [x] This comment contains a description of changes (with reason).
- [x] Make sure your code lints (`nf-core pipelines lint`).
- [x] Ensure the test suite passes (`nextflow run . -profile test,docker --outdir <OUTDIR>`).
- [x] Check for unexpected warnings in debug mode (`nextflow run . -profile debug,test,docker --outdir <OUTDIR>`).
