### PR TITLE
Refactor tool-specific subworkflows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,25 +3,6 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### `Added`
-
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Created a local `cnvkit_pon` subworkflow encapsulating CRAM-to-BAM conversion + PON generation
-
-### `Changed`
-
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Replaced `if` guards with `.filter` on input channels so subworkflows are always called unconditionally
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Normalized `take:` parameter names to `ch_` prefix and emit names to snake_case across all local subworkflows
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Removed all `.set` operators from local subworkflow code
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Moved `data_type` injection into `prepare_alignment` subworkflow instead of at each call site
-
-### `Fixed`
-
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `_closure15` error when mutect2 is not in tools by filtering `dict` and `mutect2_target_bed` channels
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `gens_pon` bug where `ch_readcounts_out` was initialized but never assigned
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `mutect2.config` `saveAs` closure parameter name shadowing the outer `meta` variable
-
 ## [1.0.0](https://github.com/nf-core/createpanelrefs/releases/tag/1.0.0) - Hell's Gate
 
 Hell's Gate National Park is a national park situated near Lake Naivasha in Kenya.
@@ -38,6 +19,7 @@ Initial release of nf-core/createpanelrefs, created with the [nf-core](https://n
 - [#50](https://github.com/nf-core/createpanelrefs/pull/50) - Add auto creation of interval_list file from gens, and bed file for mutect2
 - [#62](https://github.com/nf-core/createpanelrefs/pull/62) - Add megatests
 - [#78](https://github.com/nf-core/createpanelrefs/pull/78) - Add `mutect2_intervals_num` params
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Created a local `cnvkit_pon` subworkflow encapsulating CRAM-to-BAM conversion + PON generation
 
 ### `Changed`
 
@@ -68,6 +50,12 @@ Initial release of nf-core/createpanelrefs, created with the [nf-core](https://n
 - [#79](https://github.com/nf-core/createpanelrefs/pull/79) - Extract alignment indexing into a dedicated `prepare_alignment` subworkflow used across all tools
 - [#80](https://github.com/nf-core/createpanelrefs/pull/80) - Update all modules/subworkflows to latest
 - [#81](https://github.com/nf-core/createpanelrefs/pull/81) - Refactored tools handling to use a centralized `defineToolsList()` function, aligned with the pattern used in nf-core/rnavar and nf-core/seqinspector
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Replaced `if` statements with `.filter` on input channels so subworkflows are always called unconditionally
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Normalized `take:` parameter names to `ch_` prefix and emit names to snake_case across all local subworkflows
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Removed all `.set` operators
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Simplified `prepare_alignment` subworkflow usage
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `gens_pon` bug where `ch_readcounts_out` was initialized but never assigned
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Removed time requirements for Mutect2 as intervals usage is now possible via [#78](https://github.com/nf-core/createpanelrefs/pull/78)
 
 ### `Fixed`
 
@@ -82,6 +70,7 @@ Initial release of nf-core/createpanelrefs, created with the [nf-core](https://n
 - [#72](https://github.com/nf-core/createpanelrefs/pull/72) - Adjust time resource requirement for MUTECT2
 - [#73](https://github.com/nf-core/createpanelrefs/pull/73) - More time for Mutect2
 - [#82](https://github.com/nf-core/createpanelrefs/pull/82) - Fix schema requiring `mutect2_pon_name` even when not running mutect2; replaced with runtime validation
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `gens_pon` bug where `ch_readcounts_out` was initialized but never assigned
 
 ### `Dependencies` - modules
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -50,7 +50,6 @@ Initial release of nf-core/createpanelrefs, created with the [nf-core](https://n
 - [#79](https://github.com/nf-core/createpanelrefs/pull/79) - Extract alignment indexing into a dedicated `prepare_alignment` subworkflow used across all tools
 - [#80](https://github.com/nf-core/createpanelrefs/pull/80) - Update all modules/subworkflows to latest
 - [#81](https://github.com/nf-core/createpanelrefs/pull/81) - Refactored tools handling to use a centralized `defineToolsList()` function, aligned with the pattern used in nf-core/rnavar and nf-core/seqinspector
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Replaced `if` statements with `.filter` on input channels so subworkflows are always called unconditionally
 - [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Normalized `take:` parameter names to `ch_` prefix and emit names to snake_case across all local subworkflows
 - [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Removed all `.set` operators
 - [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Simplified `prepare_alignment` subworkflow usage

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,25 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### `Added`
+
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Created a local `cnvkit_pon` subworkflow encapsulating CRAM-to-BAM conversion + PON generation
+
+### `Changed`
+
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Replaced `if` guards with `.filter` on input channels so subworkflows are always called unconditionally
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Normalized `take:` parameter names to `ch_` prefix and emit names to snake_case across all local subworkflows
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Removed all `.set` operators from local subworkflow code
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Moved `data_type` injection into `prepare_alignment` subworkflow instead of at each call site
+
+### `Fixed`
+
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `_closure15` error when mutect2 is not in tools by filtering `dict` and `mutect2_target_bed` channels
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `gens_pon` bug where `ch_readcounts_out` was initialized but never assigned
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `mutect2.config` `saveAs` closure parameter name shadowing the outer `meta` variable
+
 ## [1.0.0](https://github.com/nf-core/createpanelrefs/releases/tag/1.0.0) - Hell's Gate
 
 Hell's Gate National Park is a national park situated near Lake Naivasha in Kenya.

--- a/conf/base.config
+++ b/conf/base.config
@@ -55,8 +55,4 @@ process {
         ext.use_gpu = { workflow.profile.contains('gpu') }
         accelerator = { workflow.profile.contains('gpu') ? 1 : null }
     }
-
-    withName: GATK4_MUTECT2 {
-        time   = { 72.h   * task.attempt }
-    }
 }

--- a/conf/modules/cnvkit.config
+++ b/conf/modules/cnvkit.config
@@ -22,7 +22,7 @@ process {
         ]
     }
 
-    withName: SAMTOOLS_VIEW {
+    withName: '.*CNVKIT_PON:SAMTOOLS_VIEW' {
         ext.args   = {"--output-fmt bam"}
     }
 }

--- a/conf/modules/mutect2.config
+++ b/conf/modules/mutect2.config
@@ -47,7 +47,7 @@ process {
         publishDir = [
             mode: params.publish_dir_mode,
             path: { "${params.outdir}/gatk4/mutect2" },
-            saveAs: { meta.num_intervals > 1 ? null : it },
+            saveAs: { file -> meta.num_intervals > 1 ? null : file },
         ]
     }
 

--- a/main.nf
+++ b/main.nf
@@ -121,6 +121,8 @@ workflow {
         params.show_hidden,
         tools,
         params.mutect2_pon_name,
+        params.genome,
+        params.genomes,
     )
 
     PREPARE_GENOME(

--- a/main.nf
+++ b/main.nf
@@ -271,4 +271,18 @@ workflow NFCORE_CREATEPANELREFS {
         mutect2_intervals_num,
         mutect2_target_bed,
     )
+
+    emit:
+    cnvkit_bed                     = CREATEPANELREFS.out.cnvkit_bed
+    cnvkit_cnn                     = CREATEPANELREFS.out.cnvkit_cnn
+    cnvkit_cnr                     = CREATEPANELREFS.out.cnvkit_cnr
+    gens_pon                       = CREATEPANELREFS.out.gens_pon
+    gens_read_counts               = CREATEPANELREFS.out.gens_read_counts
+    germlinecnvcaller_cnv_model    = CREATEPANELREFS.out.germlinecnvcaller_cnv_model
+    germlinecnvcaller_ploidy_model = CREATEPANELREFS.out.germlinecnvcaller_ploidy_model
+    germlinecnvcaller_read_counts  = CREATEPANELREFS.out.germlinecnvcaller_read_counts
+    som_pon_gatk_genomicsdb        = CREATEPANELREFS.out.som_pon_gatk_genomicsdb
+    som_pon_gatk_index             = CREATEPANELREFS.out.som_pon_gatk_index
+    som_pon_gatk_mutect2_stats     = CREATEPANELREFS.out.som_pon_gatk_mutect2_stats
+    som_pon_gatk_vcf               = CREATEPANELREFS.out.som_pon_gatk_vcf
 }

--- a/subworkflows/local/cnvkit_pon/main.nf
+++ b/subworkflows/local/cnvkit_pon/main.nf
@@ -8,7 +8,7 @@ workflow CNVKIT_PON {
     ch_cnvkit_targets // channel: [mandatory] [ val(meta), path(targets) ]
 
     main:
-    ch_split = ch_reads_index.branch { meta, reads, index ->
+    ch_reads = ch_reads_index.branch { meta, reads, index ->
         bam: meta.data_type == "bam"
         return [meta, reads]
         cram: meta.data_type == "cram"
@@ -16,7 +16,7 @@ workflow CNVKIT_PON {
     }
 
     SAMTOOLS_VIEW(
-        ch_split.cram,
+        ch_reads.cram,
         ch_fasta.map { meta, fasta_ -> [meta, fasta_, []] },
         [[:], []],
         [[:], []],
@@ -24,7 +24,7 @@ workflow CNVKIT_PON {
     )
 
     CNVKIT_BATCH(
-        ch_split.bam.mix(SAMTOOLS_VIEW.out.bam).map { meta, bam -> [[id: 'panel'], bam] }.groupTuple().map { meta, bam -> [meta, [], [], bam, []] },
+        ch_reads.bam.mix(SAMTOOLS_VIEW.out.bam).map { meta, bam -> [[id: 'panel'], bam] }.groupTuple().map { meta, bam -> [meta, [], [], bam, []] },
         ch_fasta.map { meta, fasta_ -> [meta, fasta_, []] },
         ch_cnvkit_targets,
         [[:], []],

--- a/subworkflows/local/cnvkit_pon/main.nf
+++ b/subworkflows/local/cnvkit_pon/main.nf
@@ -1,0 +1,39 @@
+include { CNVKIT_BATCH  } from '../../../modules/nf-core/cnvkit/batch'
+include { SAMTOOLS_VIEW } from '../../../modules/nf-core/samtools/view'
+
+workflow CNVKIT_PON {
+    take:
+    ch_reads_index // channel: [mandatory] [ val(meta), path(bam|cram), path(bai|crai) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
+    ch_cnvkit_targets // channel: [mandatory] [ val(meta), path(targets) ]
+
+    main:
+    ch_split = ch_reads_index.branch { meta, reads, index ->
+        bam: meta.data_type == "bam"
+        return [meta, reads]
+        cram: meta.data_type == "cram"
+        return [meta, reads, index]
+    }
+
+    SAMTOOLS_VIEW(
+        ch_split.cram,
+        ch_fasta.map { meta, fasta_ -> [meta, fasta_, []] },
+        [[:], []],
+        [[:], []],
+        false,
+    )
+
+    CNVKIT_BATCH(
+        ch_split.bam.mix(SAMTOOLS_VIEW.out.bam).map { meta, bam -> [[id: 'panel'], bam] }.groupTuple().map { meta, bam -> [meta, [], [], bam, []] },
+        ch_fasta.map { meta, fasta_ -> [meta, fasta_, []] },
+        ch_cnvkit_targets,
+        [[:], []],
+        true,
+    )
+
+    emit:
+    cnn = CNVKIT_BATCH.out.cnn // channel: [ val(meta), path(cnn) ]
+    bed = CNVKIT_BATCH.out.bed // channel: [ val(meta), path(bed) ]
+    cnr = CNVKIT_BATCH.out.cnr // channel: [ val(meta), path(cnr) ]
+    cns = CNVKIT_BATCH.out.cns // channel: [ val(meta), path(cns) ]
+}

--- a/subworkflows/local/gens_pon/main.nf
+++ b/subworkflows/local/gens_pon/main.nf
@@ -9,7 +9,7 @@ include { SAMTOOLS_VIEW                       } from '../../../modules/nf-core/s
 
 workflow GENS_PON {
     take:
-    ch_input // channel: [mandatory] [ val(meta), path(bam/cram), path(bai/crai) ]
+    ch_reads_index // channel: [mandatory] [ val(meta), path(bam/cram), path(bai/crai) ]
     val_analysis_type // string: [mandatory] type of analysis ('lrs' or 'srs')
     val_pon_name //  string: [optional] name for panel of normals
     ch_dict // channel: [optional] [ val(meta), path(dict) ]
@@ -18,21 +18,18 @@ workflow GENS_PON {
     ch_interval_list // channel: [mandatory] [ val(meta), path(interval_list) ]
 
     main:
-    ch_readcounts_out = channel.empty()
-
-    ch_input.set { ch_bam_bai }
+    ch_readcounts = channel.empty()
 
     if (val_analysis_type == 'srs') {
-        ch_bam_bai
-            .combine(ch_interval_list.map { _meta, interval_list -> interval_list })
-            .set { ch_readcounts_in }
-
         // Collect read counts, and generate models
-        GATK4_COLLECTREADCOUNTS(ch_readcounts_in, ch_fasta, ch_fai, ch_dict)
+        GATK4_COLLECTREADCOUNTS(
+            ch_reads_index.combine(ch_interval_list.map { _meta, interval_list -> interval_list }),
+            ch_fasta,
+            ch_fai,
+            ch_dict,
+        )
 
-        GATK4_COLLECTREADCOUNTS.out.tsv
-            .mix(GATK4_COLLECTREADCOUNTS.out.hdf5)
-            .set { ch_readcounts }
+        ch_readcounts = GATK4_COLLECTREADCOUNTS.out.tsv.mix(GATK4_COLLECTREADCOUNTS.out.hdf5)
     }
     else if (val_analysis_type == 'lrs') {
 
@@ -42,23 +39,16 @@ workflow GENS_PON {
             [],
         )
 
-        ch_bam_bai
-            .combine(INTERVAL_LIST_TO_BED.out.output)
-            .map { meta, bam, bai, _bins_meta, bins ->
-                [meta, bam, bai, bins]
-            }
-            .set { ch_mosdepth_in }
-
         // Prepare the body
         MOSDEPTH(
-            ch_mosdepth_in,
+            ch_reads_index.combine(INTERVAL_LIST_TO_BED.out.output).map { meta, bam, bai, _bins_meta, bins -> [meta, bam, bai, bins] },
             [[], []],
             false,
         )
 
         // Prepare the header
         SAMTOOLS_VIEW(
-            ch_bam_bai,
+            ch_reads_index,
             [[:], [], []],
             [[:], []],
             [[:], []],
@@ -77,28 +67,16 @@ workflow GENS_PON {
             false,
         )
         // Prepare GATK inputs
-        MOSDEPTH_GATK_HEADER.out.output
-            .join(MOSDEPTH_GATK_FORMAT.out.output)
-            .map { meta, header, body -> [meta, [header, body]] }
-            .set { ch_cat_in }
+        FIND_CONCATENATE(MOSDEPTH_GATK_HEADER.out.output.join(MOSDEPTH_GATK_FORMAT.out.output).map { meta, header, body -> [meta, [header, body]] })
 
-        FIND_CONCATENATE(ch_cat_in)
-
-        FIND_CONCATENATE.out.file_out
-            .map { meta, gatk_input ->
-                return [meta, gatk_input]
-            }
-            .set { ch_readcounts }
+        ch_readcounts = FIND_CONCATENATE.out.file_out.map { meta, gatk_input ->
+            return [meta, gatk_input]
+        }
     }
 
-    ch_readcounts
-        .collect { _meta, readcounts -> readcounts }
-        .map { readcounts -> [[id: val_pon_name], readcounts] }
-        .set { ch_create_pon_in }
-
-    GATK4_CREATEREADCOUNTPANELOFNORMALS(ch_create_pon_in)
+    GATK4_CREATEREADCOUNTPANELOFNORMALS(ch_readcounts.collect { _meta, readcounts -> readcounts }.map { readcounts -> [[id: val_pon_name], readcounts] })
 
     emit:
-    genspon    = GATK4_CREATEREADCOUNTPANELOFNORMALS.out.pon
-    readcounts = ch_readcounts_out
+    gens_pon    = GATK4_CREATEREADCOUNTPANELOFNORMALS.out.pon
+    read_counts = ch_readcounts
 }

--- a/subworkflows/local/germlinecnvcaller_cohort/main.nf
+++ b/subworkflows/local/germlinecnvcaller_cohort/main.nf
@@ -12,7 +12,7 @@ include { GATK4_PREPROCESSINTERVALS                                    } from '.
 
 workflow GERMLINECNVCALLER_COHORT {
     take:
-    ch_input // channel: [mandatory] [ val(meta), path(bam/cram), path(bai/crai) ]
+    ch_reads_index // channel: [mandatory] [ val(meta), path(bam/cram), path(bai/crai) ]
     val_pon_name //  string: [optional] name for panel of normals
     ch_dict // channel: [optional] [ val(meta), path(dict) ]
     ch_fai // channel: [optional] [ val(meta), path(fai) ]
@@ -36,7 +36,7 @@ workflow GERMLINECNVCALLER_COHORT {
     //Runs for wes analysis, when exclude_bed file is provided instead of target_interval_list
     GATK4_BEDTOINTERVALLIST_EXCLUDE(ch_exclude_bed, ch_dict)
 
-    ch_user_target_interval_list
+    ch_targets_for_mix = ch_user_target_interval_list
         .combine(GATK4_BEDTOINTERVALLIST_TARGETS.out.interval_list.ifEmpty(null))
         .branch { it ->
             intervallistfrompath: it[2].equals(null)
@@ -44,14 +44,12 @@ workflow GERMLINECNVCALLER_COHORT {
             intervallistfrombed: !it[2].equals(null)
             return [it[2], it[3]]
         }
-        .set { ch_targets_for_mix }
 
-    ch_targets_for_mix.intervallistfrompath
+    ch_target_interval_list = ch_targets_for_mix.intervallistfrompath
         .mix(ch_targets_for_mix.intervallistfrombed)
         .collect()
-        .set { ch_target_interval_list }
 
-    ch_user_exclude_interval_list
+    ch_exclude_for_mix = ch_user_exclude_interval_list
         .combine(GATK4_BEDTOINTERVALLIST_EXCLUDE.out.interval_list.ifEmpty(null))
         .branch { it ->
             intervallistfrompath: it[2].equals(null)
@@ -59,12 +57,10 @@ workflow GERMLINECNVCALLER_COHORT {
             intervallistfrombed: !it[2].equals(null)
             return [it[2], it[3]]
         }
-        .set { ch_exclude_for_mix }
 
-    ch_exclude_for_mix.intervallistfrompath
+    ch_exclude_interval_list = ch_exclude_for_mix.intervallistfrompath
         .mix(ch_exclude_for_mix.intervallistfrombed)
         .collect()
-        .set { ch_exclude_interval_list }
 
     GATK4_PREPROCESSINTERVALS(
         ch_fasta,
@@ -85,9 +81,7 @@ workflow GERMLINECNVCALLER_COHORT {
         GATK4_INDEXFEATUREFILE_SEGDUP.out.index.ifEmpty([[:], []]),
     )
 
-    ch_input
-        .combine(GATK4_PREPROCESSINTERVALS.out.interval_list.map { it -> it[1] })
-        .set { ch_readcounts_in }
+    ch_readcounts_in = ch_reads_index.combine(GATK4_PREPROCESSINTERVALS.out.interval_list.map { it -> it[1] })
 
     // Collect read counts, and generate models
     GATK4_COLLECTREADCOUNTS(
@@ -97,11 +91,10 @@ workflow GERMLINECNVCALLER_COHORT {
         ch_dict,
     )
 
-    GATK4_COLLECTREADCOUNTS.out.tsv
+    ch_readcounts_out = GATK4_COLLECTREADCOUNTS.out.tsv
         .mix(GATK4_COLLECTREADCOUNTS.out.hdf5)
         .collect { _meta, file -> [file] }
         .map { tsv -> [[id: val_pon_name], tsv] }
-        .set { ch_readcounts_out }
 
 
     GATK4_FILTERINTERVALS(
@@ -110,12 +103,11 @@ workflow GERMLINECNVCALLER_COHORT {
         GATK4_ANNOTATEINTERVALS.out.annotated_intervals,
     )
 
-    GATK4_INTERVALLISTTOOLS(GATK4_FILTERINTERVALS.out.interval_list).interval_list.map { _meta, it -> it }.flatten().set { ch_intervallist_out }
+    ch_intervallist_out = GATK4_INTERVALLISTTOOLS(GATK4_FILTERINTERVALS.out.interval_list).interval_list.map { _meta, it -> it }.flatten()
 
-    ch_readcounts_out
+    ch_contigploidy_in = ch_readcounts_out
         .combine(GATK4_FILTERINTERVALS.out.interval_list)
         .map { meta, counts, _meta2, il -> [meta, counts, il, []] }
-        .set { ch_contigploidy_in }
 
     GATK4_DETERMINEGERMLINECONTIGPLOIDY(
         ch_contigploidy_in,
@@ -123,16 +115,15 @@ workflow GERMLINECNVCALLER_COHORT {
         ch_ploidy_priors,
     )
 
-    ch_readcounts_out
+    ch_cnvcaller_in = ch_readcounts_out
         .combine(ch_intervallist_out)
         .combine(GATK4_DETERMINEGERMLINECONTIGPLOIDY.out.calls)
         .map { meta, counts, il, _meta2, calls -> [meta + [id: il.baseName], counts, il, calls, []] }
-        .set { ch_cnvcaller_in }
 
     GATK4_GERMLINECNVCALLER(ch_cnvcaller_in)
 
     emit:
-    cnvmodel    = GATK4_GERMLINECNVCALLER.out.cohortmodel
-    ploidymodel = GATK4_DETERMINEGERMLINECONTIGPLOIDY.out.model
-    readcounts  = ch_readcounts_out
+    cnv_model    = GATK4_GERMLINECNVCALLER.out.cohortmodel
+    ploidy_model = GATK4_DETERMINEGERMLINECONTIGPLOIDY.out.model
+    read_counts  = ch_readcounts_out
 }

--- a/subworkflows/local/prepare_alignment/main.nf
+++ b/subworkflows/local/prepare_alignment/main.nf
@@ -6,18 +6,18 @@ include { SAMTOOLS_INDEX } from '../../../modules/nf-core/samtools/index'
 
 workflow PREPARE_ALIGNMENT {
     take:
-    samplesheet // [ val(meta), path(bam), path(bai), path(cram), path(crai) ]
+    ch_samplesheet // [ val(meta), path(bam), path(bai), path(cram), path(crai) ]
     tools // list: tools to run
 
     main:
     def index_bams = tools.any { tool -> tool in ['germlinecnvcaller', 'gens', 'mutect2'] }
     def index_crams = tools.any { tool -> tool in ['germlinecnvcaller', 'gens', 'mutect2'] }
 
-    ch_bam = samplesheet
+    ch_bam = ch_samplesheet
         .filter { _meta, bam, _bai, _cram, _crai -> bam }
         .map { meta, bam, bai, _cram, _crai -> [meta, bam, bai] }
 
-    ch_cram = samplesheet
+    ch_cram = ch_samplesheet
         .filter { _meta, _bam, _bai, cram, _crai -> cram }
         .map { meta, _bam, _bai, cram, crai -> [meta, cram, crai] }
 
@@ -34,10 +34,11 @@ workflow PREPARE_ALIGNMENT {
 
     SAMTOOLS_INDEX(to_index)
 
-    ch_reads_index = input_reads.indexed.mix(input_reads.not_indexed.filter { _meta, reads -> !((reads.extension == "bam" && index_bams) || (reads.extension == "cram" && index_crams)) }.map { meta, reads -> [meta, reads, []] }).mix(to_index.join(SAMTOOLS_INDEX.out.index, failOnMismatch: true, failOnDuplicate: true)) // [ val(meta), path(bam|cram), path(bai|crai) ]
+    ch_reads_index = input_reads.indexed
+        .mix(input_reads.not_indexed.filter { _meta, reads -> !((reads.extension == "bam" && index_bams) || (reads.extension == "cram" && index_crams)) }.map { meta, reads -> [meta, reads, []] })
+        .mix(to_index.join(SAMTOOLS_INDEX.out.index, failOnMismatch: true, failOnDuplicate: true))
+        .map { meta, reads, index -> [meta + [data_type: reads.extension], reads, index] }
 
     emit:
     reads_index = ch_reads_index // [ val(meta), path(bam|cram), path(bai|crai) ]
-    bam_index = ch_reads_index.filter { _meta, reads, _index -> reads.extension == "bam" } // [ val(meta), path(bam), path(bai) ]
-    cram_index = ch_reads_index.filter { _meta, reads, _index -> reads.extension == "cram" } // [ val(meta), path(cram), path(crai) ]
 }

--- a/subworkflows/local/prepare_genome/main.nf
+++ b/subworkflows/local/prepare_genome/main.nf
@@ -4,78 +4,77 @@ include { GATK4_SPLITINTERVALS                                        } from '..
 include { GAWK as BUILD_INTERVALS                                     } from '../../../modules/nf-core/gawk'
 include { SAMTOOLS_FAIDX                                              } from '../../../modules/nf-core/samtools/faidx'
 
-//  Prepare references
 workflow PREPARE_GENOME {
     take:
-    fasta // channel: [mandatory] [ val(meta), path(fasta) ]
-    user_dict // channel: [optional]  [ val(meta), path(dict) ]
-    user_fai // channel: [optional]  [ val(meta), path(fai) ]
-    user_gens_interval_list // channel: [optional]  [ val(meta), path(gens_interval_list) ]
-    user_mutect2_target_bed // channel: [optional]  [ val(meta), path(mutect2_target_bed) ]
+    ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
+    ch_user_dict // channel: [optional]  [ val(meta), path(dict) ]
+    ch_user_fai // channel: [optional]  [ val(meta), path(fai) ]
+    ch_user_gens_interval_list // channel: [optional]  [ val(meta), path(gens_interval_list) ]
+    ch_user_mutect2_target_bed // channel: [optional]  [ val(meta), path(mutect2_target_bed) ]
     mutect2_intervals_num //   value: [optional] number of intervals for mutect2 scatter
     tools //   list: [mandatory] tools to run
 
     main:
-    dict = channel.empty()
-    fai = channel.empty()
-    gens_interval_list = channel.empty()
+    ch_dict = channel.empty()
+    ch_fai = channel.empty()
+    ch_gens_interval_list = channel.empty()
     intervals_num = channel.empty()
-    mutect2_target_bed = channel.empty()
+    ch_mutect2_target_bed = channel.empty()
 
     // If a user_dict is provided, no fasta will be used to generate a dict
     // Otherwise, GATK4_CREATESEQUENCEDICTIONARY will be run to generate a dict
-    fasta_for_dict = fasta
-        .mix(user_dict)
+    ch_fasta_for_dict = ch_fasta
+        .mix(ch_user_dict)
         .groupTuple()
         .filter { _meta, files -> !files[1] }
 
-    GATK4_CREATESEQUENCEDICTIONARY(fasta_for_dict)
+    GATK4_CREATESEQUENCEDICTIONARY(ch_fasta_for_dict)
 
-    dict = user_dict.mix(GATK4_CREATESEQUENCEDICTIONARY.out.dict).collect()
+    ch_dict = ch_user_dict.mix(GATK4_CREATESEQUENCEDICTIONARY.out.dict).collect()
 
     // If a user_fai is provided, no fasta will be used to generate a fai
     // Otherwise, SAMTOOLS_FAIDX will be run to generate a fai
-    fasta_for_fai = fasta
-        .mix(user_fai)
+    ch_fasta_for_fai = ch_fasta
+        .mix(ch_user_fai)
         .groupTuple()
         .filter { _meta, files -> !files[1] }
         .map { meta, fasta_ -> [meta, fasta_, []] }
 
-    SAMTOOLS_FAIDX(fasta_for_fai, false)
+    SAMTOOLS_FAIDX(ch_fasta_for_fai, false)
 
-    fai = user_fai.mix(SAMTOOLS_FAIDX.out.fai).collect()
+    ch_fai = ch_user_fai.mix(SAMTOOLS_FAIDX.out.fai).collect()
 
     // If a user_gens_interval_list is provided or if gens is not a specified tools, no fasta will be used to generate an interval list
     // Otherwise, GATK4_PREPROCESSINTERVALS_GENS will be run to generate an interval list
-    fasta_for_interval_list = fasta
-        .mix(user_gens_interval_list)
+    ch_fasta_for_interval_list = ch_fasta
+        .mix(ch_user_gens_interval_list)
         .groupTuple()
         .filter { _meta, files -> ('gens' in tools && !files[1]) }
 
-    GATK4_PREPROCESSINTERVALS_GENS(fasta_for_interval_list, fai.collect(), dict.collect(), [[:], []], [[:], []])
+    GATK4_PREPROCESSINTERVALS_GENS(ch_fasta_for_interval_list, ch_fai.collect(), ch_dict.collect(), [[:], []], [[:], []])
 
-    gens_interval_list = user_gens_interval_list.mix(GATK4_PREPROCESSINTERVALS_GENS.out.interval_list).collect()
+    ch_gens_interval_list = ch_user_gens_interval_list.mix(GATK4_PREPROCESSINTERVALS_GENS.out.interval_list).collect()
 
     // If a user_mutect2_target_bed is provided or if mutect2 is not a specified tools, no fai will be used to generate a target bed
     // Otherwise, BUILD_INTERVALS will be run to generate a target bed
-    fai_for_intervals = fai
-        .mix(user_mutect2_target_bed)
+    ch_fai_for_intervals = ch_fai
+        .mix(ch_user_mutect2_target_bed)
         .groupTuple()
         .filter { _meta, files -> ('mutect2' in tools && !files[1]) }
 
-    BUILD_INTERVALS(fai_for_intervals, [], false)
+    BUILD_INTERVALS(ch_fai_for_intervals, [], false)
 
-    mutect2_target_bed = user_mutect2_target_bed.mix(BUILD_INTERVALS.out.output).collect()
+    ch_mutect2_target_bed = ch_user_mutect2_target_bed.mix(BUILD_INTERVALS.out.output).collect()
 
     // If mutect2 is in tools and mutect2_intervals_num > 1, split intervals for scatter/gather strategy
-    // ch_intervals_num: [ path(intervals), val(num_intervals) ]
+    // intervals_num: [ path(intervals), val(num_intervals) ]
     // num_intervals > 1 triggers per-interval scatter and merge of outputs
     if ('mutect2' in tools && mutect2_intervals_num > 1) {
         GATK4_SPLITINTERVALS(
-            mutect2_target_bed,
-            fasta,
-            fai,
-            dict,
+            ch_mutect2_target_bed,
+            ch_fasta,
+            ch_fai,
+            ch_dict,
         )
 
         intervals_num = GATK4_SPLITINTERVALS.out.split_intervals.flatMap { _meta, intervals -> intervals.collect { interval -> [interval, intervals.size()] } }
@@ -85,9 +84,9 @@ workflow PREPARE_GENOME {
     }
 
     emit:
-    dict // channel: [ val(meta), path(dict) ]
-    fai // channel: [ val(meta), path(fai) ]
-    gens_interval_list // channel: [ val(meta), path(gens_interval_list) ]
+    dict = ch_dict // channel: [ val(meta), path(dict) ]
+    fai = ch_fai // channel: [ val(meta), path(fai) ]
+    gens_interval_list = ch_gens_interval_list // channel: [ val(meta), path(gens_interval_list) ]
     intervals_num // channel: [ path(intervals), val(num_intervals) ]
-    mutect2_target_bed // channel: [ val(meta), path(mutect2_target_bed) ]
+    mutect2_target_bed = ch_mutect2_target_bed // channel: [ val(meta), path(mutect2_target_bed) ]
 }

--- a/subworkflows/local/utils_nfcore_createpanelrefs_pipeline/main.nf
+++ b/subworkflows/local/utils_nfcore_createpanelrefs_pipeline/main.nf
@@ -36,6 +36,8 @@ workflow PIPELINE_INITIALISATION {
     show_hidden // boolean: Show hidden parameters in the help message
     tools
     mutect2_pon_name
+    genome
+    genomes
 
     main:
 
@@ -114,6 +116,8 @@ workflow PIPELINE_INITIALISATION {
     // Custom validation for pipeline parameters
     //
     validateInputParameters(
+        genome,
+        genomes,
         mutect2_pon_name,
         tools,
     )
@@ -121,7 +125,6 @@ workflow PIPELINE_INITIALISATION {
     //
     // Create channel from input file provided through input
     //
-
     ch_samplesheet = channel.fromList(samplesheetToList(input, "${projectDir}/assets/schema_input.json"))
 
     emit:
@@ -180,17 +183,17 @@ workflow PIPELINE_COMPLETION {
 //
 // Check and validate pipeline parameters
 //
-def validateInputParameters(mutect2_pon_name, tools) {
-    genomeExistsError()
+def validateInputParameters(genome, genomes, mutect2_pon_name, tools) {
+    genomeExistsError(genome, genomes)
     mutect2PonNameError(mutect2_pon_name, 'mutect2' in tools)
 }
 
 //
 // Exit pipeline if incorrect --genome key provided
 //
-def genomeExistsError() {
-    if (params.genomes && params.genome && !params.genomes.containsKey(params.genome)) {
-        def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" + "  Genome '${params.genome}' not found in any config files provided to the pipeline.\n" + "  Currently, the available genome keys are:\n" + "  ${params.genomes.keySet().join(", ")}\n" + "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
+def genomeExistsError(genome, genomes) {
+    if (genomes && genome && !genomes.containsKey(genome)) {
+        def error_string = "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~\n" + "  Genome '${genome}' not found in any config files provided to the pipeline.\n" + "  Currently, the available genome keys are:\n" + "  ${genomes.keySet().join(", ")}\n" + "~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~"
         error(error_string)
     }
 }

--- a/workflows/createpanelrefs.nf
+++ b/workflows/createpanelrefs.nf
@@ -34,6 +34,16 @@ workflow CREATEPANELREFS {
     mutect2_target_bed // channel: [meta, mutect2_target_bed]
 
     main:
+    ch_gens_pon = channel.empty()
+    ch_gens_read_counts = channel.empty()
+    ch_germlinecnvcaller_cnv_model = channel.empty()
+    ch_germlinecnvcaller_ploidy_model = channel.empty()
+    ch_germlinecnvcaller_read_counts = channel.empty()
+    ch_som_pon_gatk_genomicsdb = channel.empty()
+    ch_som_pon_gatk_index = channel.empty()
+    ch_som_pon_gatk_mutect2_stats = channel.empty()
+    ch_som_pon_gatk_vcf = channel.empty()
+
     // Auto-index alignment files if indexes are missing from the samplesheet
     PREPARE_ALIGNMENT(samplesheet, tools)
 
@@ -45,40 +55,71 @@ workflow CREATEPANELREFS {
     )
 
     // GENS
-    GENS_PON(
-        PREPARE_ALIGNMENT.out.reads_index.filter { 'gens' in tools },
-        gens_analysis_type,
-        gens_pon_name,
-        dict,
-        fai,
-        fasta,
-        gens_interval_list.filter { 'gens' in tools },
-    )
+    if ('gens' in tools) {
+        GENS_PON(
+            PREPARE_ALIGNMENT.out.reads_index,
+            gens_analysis_type,
+            gens_pon_name,
+            dict,
+            fai,
+            fasta,
+            gens_interval_list,
+        )
+
+        ch_gens_pon = GENS_PON.out.gens_pon
+        ch_gens_read_counts = GENS_PON.out.read_counts
+    }
 
     // GERMLINECNVCALLER
-    GERMLINECNVCALLER_COHORT(
-        PREPARE_ALIGNMENT.out.reads_index.filter { 'germlinecnvcaller' in tools },
-        gcnv_model_name,
-        dict,
-        fai,
-        fasta,
-        gcnv_exclude_bed.filter { 'germlinecnvcaller' in tools },
-        gcnv_exclude_interval_list.filter { 'germlinecnvcaller' in tools },
-        gcnv_mappable_regions.filter { 'germlinecnvcaller' in tools },
-        gcnv_ploidy_priors,
-        gcnv_segmental_duplications.filter { 'germlinecnvcaller' in tools },
-        gcnv_target_bed.filter { 'germlinecnvcaller' in tools },
-        gcnv_target_interval_list.filter { 'germlinecnvcaller' in tools },
-    )
+    if ('germlinecnvcaller' in tools) {
+        GERMLINECNVCALLER_COHORT(
+            PREPARE_ALIGNMENT.out.reads_index,
+            gcnv_model_name,
+            dict,
+            fai,
+            fasta,
+            gcnv_exclude_bed,
+            gcnv_exclude_interval_list,
+            gcnv_mappable_regions,
+            gcnv_ploidy_priors,
+            gcnv_segmental_duplications,
+            gcnv_target_bed,
+            gcnv_target_interval_list,
+        )
+
+        ch_germlinecnvcaller_cnv_model = GERMLINECNVCALLER_COHORT.out.cnv_model
+        ch_germlinecnvcaller_ploidy_model = GERMLINECNVCALLER_COHORT.out.ploidy_model
+        ch_germlinecnvcaller_read_counts = GERMLINECNVCALLER_COHORT.out.read_counts
+    }
 
     // MUTECT2
-    BAM_CREATE_SOM_PON_GATK(
-        PREPARE_ALIGNMENT.out.reads_index.filter { 'mutect2' in tools },
-        fasta,
-        fai.map { meta, fai_ -> [meta, fai_, []] },
-        dict.filter { 'mutect2' in tools },
-        mutect2_pon_name,
-        mutect2_target_bed.filter { 'mutect2' in tools }.map { _meta, target -> [target] },
-        intervals_num,
-    )
+    if ('mutect2' in tools) {
+        BAM_CREATE_SOM_PON_GATK(
+            PREPARE_ALIGNMENT.out.reads_index,
+            fasta,
+            fai.map { meta, fai_ -> [meta, fai_, []] },
+            dict,
+            mutect2_pon_name,
+            mutect2_target_bed.map { _meta, target -> [target] },
+            intervals_num,
+        )
+        ch_som_pon_gatk_genomicsdb = BAM_CREATE_SOM_PON_GATK.out.genomicsdb
+        ch_som_pon_gatk_index = BAM_CREATE_SOM_PON_GATK.out.pon_index
+        ch_som_pon_gatk_mutect2_stats = BAM_CREATE_SOM_PON_GATK.out.mutect2_stats
+        ch_som_pon_gatk_vcf = BAM_CREATE_SOM_PON_GATK.out.pon_vcf
+    }
+
+    emit:
+    cnvkit_bed                     = CNVKIT_PON.out.bed
+    cnvkit_cnn                     = CNVKIT_PON.out.cnn
+    cnvkit_cnr                     = CNVKIT_PON.out.cnr
+    gens_pon                       = ch_gens_pon
+    gens_read_counts               = ch_gens_read_counts
+    germlinecnvcaller_cnv_model    = ch_germlinecnvcaller_cnv_model
+    germlinecnvcaller_ploidy_model = ch_germlinecnvcaller_ploidy_model
+    germlinecnvcaller_read_counts  = ch_germlinecnvcaller_read_counts
+    som_pon_gatk_genomicsdb        = ch_som_pon_gatk_genomicsdb
+    som_pon_gatk_index             = ch_som_pon_gatk_index
+    som_pon_gatk_mutect2_stats     = ch_som_pon_gatk_mutect2_stats
+    som_pon_gatk_vcf               = ch_som_pon_gatk_vcf
 }

--- a/workflows/createpanelrefs.nf
+++ b/workflows/createpanelrefs.nf
@@ -5,11 +5,10 @@
 */
 
 include { BAM_CREATE_SOM_PON_GATK  } from '../subworkflows/nf-core/bam_create_som_pon_gatk'
-include { CNVKIT_BATCH             } from '../modules/nf-core/cnvkit/batch'
+include { CNVKIT_PON               } from '../subworkflows/local/cnvkit_pon'
 include { GENS_PON                 } from '../subworkflows/local/gens_pon'
 include { GERMLINECNVCALLER_COHORT } from '../subworkflows/local/germlinecnvcaller_cohort'
 include { PREPARE_ALIGNMENT        } from '../subworkflows/local/prepare_alignment'
-include { SAMTOOLS_VIEW            } from '../modules/nf-core/samtools/view'
 
 workflow CREATEPANELREFS {
     take:
@@ -38,72 +37,48 @@ workflow CREATEPANELREFS {
     // Auto-index alignment files if indexes are missing from the samplesheet
     PREPARE_ALIGNMENT(samplesheet, tools)
 
-    if ('cnvkit' in tools) {
+    //CNVKIT
+    CNVKIT_PON(
+        PREPARE_ALIGNMENT.out.reads_index.filter { 'cnvkit' in tools },
+        fasta,
+        cnvkit_targets,
+    )
 
-        SAMTOOLS_VIEW(
-            PREPARE_ALIGNMENT.out.cram_index,
-            fasta.map { meta, fasta_ -> [meta, fasta_, []] },
-            [[:], []],
-            [[:], []],
-            false,
-        )
+    // GENS
+    GENS_PON(
+        PREPARE_ALIGNMENT.out.reads_index.filter { 'gens' in tools },
+        gens_analysis_type,
+        gens_pon_name,
+        dict,
+        fai,
+        fasta,
+        gens_interval_list.filter { 'gens' in tools },
+    )
 
-        CNVKIT_BATCH(
-            PREPARE_ALIGNMENT.out.bam_index.map { meta, bam, _bai -> [meta, bam] }.mix(SAMTOOLS_VIEW.out.bam).map { meta, bam -> [meta + [id: 'panel'], bam] }.groupTuple().map { meta, bam -> [meta, [], [], bam, []] },
-            fasta.map { meta, fasta_ -> [meta, fasta_, []] },
-            cnvkit_targets,
-            [[:], []],
-            true,
-        )
-    }
+    // GERMLINECNVCALLER
+    GERMLINECNVCALLER_COHORT(
+        PREPARE_ALIGNMENT.out.reads_index.filter { 'germlinecnvcaller' in tools },
+        gcnv_model_name,
+        dict,
+        fai,
+        fasta,
+        gcnv_exclude_bed.filter { 'germlinecnvcaller' in tools },
+        gcnv_exclude_interval_list.filter { 'germlinecnvcaller' in tools },
+        gcnv_mappable_regions.filter { 'germlinecnvcaller' in tools },
+        gcnv_ploidy_priors,
+        gcnv_segmental_duplications.filter { 'germlinecnvcaller' in tools },
+        gcnv_target_bed.filter { 'germlinecnvcaller' in tools },
+        gcnv_target_interval_list.filter { 'germlinecnvcaller' in tools },
+    )
 
-    if ('gens' in tools) {
-
-        gens_input = PREPARE_ALIGNMENT.out.reads_index.map { meta, reads, index -> [meta + [data_type: reads.extension], reads, index] }
-
-        GENS_PON(
-            gens_input,
-            gens_analysis_type,
-            gens_pon_name,
-            dict,
-            fai,
-            fasta,
-            gens_interval_list,
-        )
-    }
-
-    if ('germlinecnvcaller' in tools) {
-
-        germlinecnvcaller_input = PREPARE_ALIGNMENT.out.reads_index.map { meta, reads, index -> [meta + [data_type: reads.extension], reads, index] }
-
-        GERMLINECNVCALLER_COHORT(
-            germlinecnvcaller_input,
-            gcnv_model_name,
-            dict,
-            fai,
-            fasta,
-            gcnv_exclude_bed,
-            gcnv_exclude_interval_list,
-            gcnv_mappable_regions,
-            gcnv_ploidy_priors,
-            gcnv_segmental_duplications,
-            gcnv_target_bed,
-            gcnv_target_interval_list,
-        )
-    }
-
-    if ('mutect2' in tools) {
-
-        mutect2_input = PREPARE_ALIGNMENT.out.reads_index.map { meta, reads, index -> [meta + [data_type: reads.extension], reads, index] }
-
-        BAM_CREATE_SOM_PON_GATK(
-            mutect2_input,
-            fasta,
-            fai.map { meta, fai_ -> [meta, fai_, []] },
-            dict,
-            mutect2_pon_name,
-            mutect2_target_bed.map { _meta, target -> [target] },
-            intervals_num,
-        )
-    }
+    // MUTECT2
+    BAM_CREATE_SOM_PON_GATK(
+        PREPARE_ALIGNMENT.out.reads_index.filter { 'mutect2' in tools },
+        fasta,
+        fai.map { meta, fai_ -> [meta, fai_, []] },
+        dict.filter { 'mutect2' in tools },
+        mutect2_pon_name,
+        mutect2_target_bed.filter { 'mutect2' in tools }.map { _meta, target -> [target] },
+        intervals_num,
+    )
 }


### PR DESCRIPTION
## Description

This PR refactors the pipeline's tool-specific subworkflows and unifies the pattern for conditionally running subworkflows.

### Changes

1. **New `cnvkit_pon` subworkflow** — encapsulates CRAM-to-BAM conversion (`SAMTOOLS_VIEW`) + PON generation (`CNVKIT_BATCH`)
2. **Replaced `if` statements with `.filter` on input channels** — subworkflows always called but receive empty channels when a tool is disabled
3. **Normalized parameter names** — all `take:` parameters use `ch_` prefix
4. **Normalized emit names to snake_case** across all local subworkflows
5. **Fixed `gens_pon` bug** — `ch_readcounts_out` was initialized but never assigned
6. **Removed all `.set` operators** from local subworkflow code
7. **Moved `data_type` to meta** inside `prepare_alignment` subworkflow
8. **Fixed `mutect2.config`** — `saveAs` closure parameter renamed from non initiated `it` to `file`