### PR TITLE
Remove ext.when from germlinecnvcaller_cohort config and handle conditions in subworkflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,6 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## Unreleased
-
-### `Changed`
-
-- [#84](https://github.com/nf-core/createpanelrefs/pull/84) - Removed `ext.when` from `germlinecnvcaller_cohort` config and moved conditional logic into the subworkflow via channel filtering
-
 ## [1.0.0](https://github.com/nf-core/createpanelrefs/releases/tag/1.0.0) - Hell's Gate
 
 Hell's Gate National Park is a national park situated near Lake Naivasha in Kenya.
@@ -55,6 +49,7 @@ Initial release of nf-core/createpanelrefs, created with the [nf-core](https://n
 - [#79](https://github.com/nf-core/createpanelrefs/pull/79) - Extract alignment indexing into a dedicated `prepare_alignment` subworkflow used across all tools
 - [#80](https://github.com/nf-core/createpanelrefs/pull/80) - Update all modules/subworkflows to latest
 - [#81](https://github.com/nf-core/createpanelrefs/pull/81) - Refactored tools handling to use a centralized `defineToolsList()` function, aligned with the pattern used in nf-core/rnavar and nf-core/seqinspector
+- [#84](https://github.com/nf-core/createpanelrefs/pull/84) - Removed `ext.when` from `germlinecnvcaller_cohort` config and moved conditional logic into the subworkflow via channel filtering
 
 ### `Fixed`
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## Unreleased
+
+### `Changed`
+
+- [#84](https://github.com/nf-core/createpanelrefs/pull/84) - Removed `ext.when` from `germlinecnvcaller_cohort` config and moved conditional logic into the subworkflow via channel filtering
+
 ## [1.0.0](https://github.com/nf-core/createpanelrefs/releases/tag/1.0.0) - Hell's Gate
 
 Hell's Gate National Park is a national park situated near Lake Naivasha in Kenya.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,25 +24,25 @@ Initial release of nf-core/createpanelrefs, created with the [nf-core](https://n
 ### `Changed`
 
 - [#19](https://github.com/nf-core/createpanelrefs/pull/19) - Updates germlinecnvcaller subworkflow to handle exome samples
-- [#24](https://github.com/nf-core/createpanelrefs/pull/24) - Updates germlinecnvcaller subworkflow to use mappability and segmental duplications track
 - [#24](https://github.com/nf-core/createpanelrefs/pull/24) - Updates germlinecnvcaller and gens subworkflows to use custom names for panel of normals.
+- [#24](https://github.com/nf-core/createpanelrefs/pull/24) - Updates germlinecnvcaller subworkflow to use mappability and segmental duplications track
 - [#28](https://github.com/nf-core/createpanelrefs/pull/28) - Updates default args for gens subworkflow and made the parameters available from the command line.
 - [#31](https://github.com/nf-core/createpanelrefs/pull/31) - Publish interval_list file from gens subworkflow by default.
-- [#35](https://github.com/nf-core/createpanelrefs/pull/35) - Template update for nf-core/tools v3.0.2
 - [#35](https://github.com/nf-core/createpanelrefs/pull/35) - Improve pipeline level tests
+- [#35](https://github.com/nf-core/createpanelrefs/pull/35) - Template update for nf-core/tools v3.0.2
 - [#48](https://github.com/nf-core/createpanelrefs/pull/48) - Improve CI (early failure + automatic nf-test shards + [RunsOn](https://runs-on.com/))
 - [#49](https://github.com/nf-core/createpanelrefs/pull/49) - Improve CI (Test Mutect2 with CRAM + better usage of test references)
 - [#49](https://github.com/nf-core/createpanelrefs/pull/49) - Move all parameters in the schema that are references in the references section
-- [#50](https://github.com/nf-core/createpanelrefs/pull/50) - Improve references related files handling
 - [#50](https://github.com/nf-core/createpanelrefs/pull/50) - Heavy refactoring of the pipeline
+- [#50](https://github.com/nf-core/createpanelrefs/pull/50) - Improve references related files handling
 - [#52](https://github.com/nf-core/createpanelrefs/pull/52) - Template update for nf-core/tools v3.2.1
 - [#54](https://github.com/nf-core/createpanelrefs/pull/54) - Template update for nf-core/tools v3.3.1
 - [#54](https://github.com/nf-core/createpanelrefs/pull/54) - Update nft-utils to 0.0.4
 - [#55](https://github.com/nf-core/createpanelrefs/pull/55) - Prepare relase 1.0.0
 - [#63](https://github.com/nf-core/createpanelrefs/pull/63) - Template update for nf-core/tools v3.5.0dev
 - [#66](https://github.com/nf-core/createpanelrefs/pull/66) - Update `GENS` to allow for creating a long-read PON
-- [#69](https://github.com/nf-core/createpanelrefs/pull/69) - Update all dependencies (modules, subworfklows and plugins)
 - [#69](https://github.com/nf-core/createpanelrefs/pull/69) - Replace `CAT_CAT` by `FIND_CONCATENATE`
+- [#69](https://github.com/nf-core/createpanelrefs/pull/69) - Update all dependencies (modules, subworfklows and plugins)
 - [#74](https://github.com/nf-core/createpanelrefs/pull/74) - Update all modules to work with singularity and apptainer
 - [#76](https://github.com/nf-core/createpanelrefs/pull/76) - Template update for nf-core/tools v4.0.1
 - [#78](https://github.com/nf-core/createpanelrefs/pull/78) - Add intervals for Mutect2 in PON creation
@@ -50,11 +50,11 @@ Initial release of nf-core/createpanelrefs, created with the [nf-core](https://n
 - [#79](https://github.com/nf-core/createpanelrefs/pull/79) - Extract alignment indexing into a dedicated `prepare_alignment` subworkflow used across all tools
 - [#80](https://github.com/nf-core/createpanelrefs/pull/80) - Update all modules/subworkflows to latest
 - [#81](https://github.com/nf-core/createpanelrefs/pull/81) - Refactored tools handling to use a centralized `defineToolsList()` function, aligned with the pattern used in nf-core/rnavar and nf-core/seqinspector
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `gens_pon` bug where `ch_readcounts_out` was initialized but never assigned
 - [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Normalized `take:` parameter names to `ch_` prefix and emit names to snake_case across all local subworkflows
 - [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Removed all `.set` operators
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Simplified `prepare_alignment` subworkflow usage
-- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Fixed `gens_pon` bug where `ch_readcounts_out` was initialized but never assigned
 - [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Removed time requirements for Mutect2 as intervals usage is now possible via [#78](https://github.com/nf-core/createpanelrefs/pull/78)
+- [#83](https://github.com/nf-core/createpanelrefs/pull/83) - Simplified `prepare_alignment` subworkflow usage
 - [#84](https://github.com/nf-core/createpanelrefs/pull/84) - Removed `ext.when` from `germlinecnvcaller_cohort` config and moved conditional logic into the subworkflow via channel filtering
 
 ### `Fixed`
@@ -63,8 +63,8 @@ Initial release of nf-core/createpanelrefs, created with the [nf-core](https://n
 - [#53](https://github.com/nf-core/createpanelrefs/pull/53) - Minor syntax fixes due to [#50](https://github.com/nf-core/createpanelrefs/pull/50)
 - [#54](https://github.com/nf-core/createpanelrefs/pull/54) - Fix name for `_mqc_versions.yml` file
 - [#56](https://github.com/nf-core/createpanelrefs/pull/56) - Fix gcnv interval list
-- [#57](https://github.com/nf-core/createpanelrefs/pull/57) - Improve syntax in `assets/schema_input.json` file, from @nvnieuwk in [#46](https://github.com/nf-core/createpanelrefs/pull/46)
 - [#57](https://github.com/nf-core/createpanelrefs/pull/57) - Fix missing documentation for GATK Mutect2 and GENS
+- [#57](https://github.com/nf-core/createpanelrefs/pull/57) - Improve syntax in `assets/schema_input.json` file, from @nvnieuwk in [#46](https://github.com/nf-core/createpanelrefs/pull/46)
 - [#70](https://github.com/nf-core/createpanelrefs/pull/70) - Fix CI issues with conda
 - [#71](https://github.com/nf-core/createpanelrefs/pull/71) - Fix time resource requirement
 - [#72](https://github.com/nf-core/createpanelrefs/pull/72) - Adjust time resource requirement for MUTECT2

--- a/conf/modules/germlinecnvcaller_cohort.config
+++ b/conf/modules/germlinecnvcaller_cohort.config
@@ -17,22 +17,6 @@ process {
         ]
     }
 
-    withName: '.*GERMLINECNVCALLER_COHORT:GATK4_INDEXFEATUREFILE_MAPPABILITY' {
-        ext.when = { !params.gcnv_mappable_regions.equals(null) }
-    }
-
-    withName: '.*GERMLINECNVCALLER_COHORT:GATK4_INDEXFEATUREFILE_SEGDUP' {
-        ext.when = { !params.gcnv_segmental_duplications.equals(null) }
-    }
-
-    withName: '.*GERMLINECNVCALLER_COHORT:GATK4_BEDTOINTERVALLIST_TARGETS' {
-        ext.when = { params.gcnv_analysis_type.equals("wes") && params.gcnv_target_interval_list.equals(null) && params.gcnv_target_bed }
-    }
-
-    withName: '.*GERMLINECNVCALLER_COHORT:GATK4_BEDTOINTERVALLIST_EXCLUDE' {
-        ext.when = { params.gcnv_analysis_type.equals("wes") && params.gcnv_exclude_interval_list.equals(null) && params.gcnv_exclude_bed }
-    }
-
     withName: '.*GERMLINECNVCALLER_COHORT:GATK4_PREPROCESSINTERVALS' {
         ext.args = { ["--imr OVERLAPPING_ONLY",
                         "--padding ${params.gcnv_padding}",

--- a/main.nf
+++ b/main.nf
@@ -138,6 +138,7 @@ workflow {
         PIPELINE_INITIALISATION.out.samplesheet,
         tools,
         params.gcnv_model_name,
+        params.gcnv_analysis_type,
         params.gens_analysis_type,
         params.gens_pon_name,
         params.mutect2_pon_name,
@@ -227,6 +228,7 @@ workflow NFCORE_CREATEPANELREFS {
     samplesheet // channel: samplesheet read in from --input
     tools // list: tools to run
     gcnv_model_name // string: name of gcnv model
+    gcnv_analysis_type // string: type of analysis for germlinecnvcaller ('wes' or 'wgs')
     gens_analysis_type // string: type of analysis for gens pon ('lrs' or 'srs')
     gens_pon_name // string: name of gens pon
     mutect2_pon_name // string: name of mutect2 pon
@@ -251,6 +253,7 @@ workflow NFCORE_CREATEPANELREFS {
         samplesheet,
         tools,
         gcnv_model_name,
+        gcnv_analysis_type,
         gens_analysis_type,
         gens_pon_name,
         mutect2_pon_name,

--- a/subworkflows/local/germlinecnvcaller_cohort/main.nf
+++ b/subworkflows/local/germlinecnvcaller_cohort/main.nf
@@ -32,8 +32,8 @@ workflow GERMLINECNVCALLER_COHORT {
     GATK4_INDEXFEATUREFILE_SEGDUP(ch_segmental_duplications.filter { _meta, segdup -> !(segdup instanceof List) })
 
     // Bed to interval list conversion — only for WES when bed is provided and no interval list given
-    ch_target_bed_interval_list = channel.value(null)
-    ch_exclude_bed_interval_list = channel.value(null)
+    ch_target_bed_interval_list = channel.empty()
+    ch_exclude_bed_interval_list = channel.empty()
 
     if (val_analysis_type == "wes") {
         GATK4_BEDTOINTERVALLIST_TARGETS(
@@ -51,7 +51,7 @@ workflow GERMLINECNVCALLER_COHORT {
     }
 
     ch_user_target_interval_list
-        .combine(ch_target_bed_interval_list)
+        .combine(ch_target_bed_interval_list.ifEmpty(null))
         .branch { it ->
             intervallistfrompath: it[2].equals(null)
             return [it[0], it[1]]
@@ -66,7 +66,7 @@ workflow GERMLINECNVCALLER_COHORT {
         .set { ch_target_interval_list }
 
     ch_user_exclude_interval_list
-        .combine(ch_exclude_bed_interval_list)
+        .combine(ch_exclude_bed_interval_list.ifEmpty(null))
         .branch { it ->
             intervallistfrompath: it[2].equals(null)
             return [it[0], it[1]]

--- a/subworkflows/local/germlinecnvcaller_cohort/main.nf
+++ b/subworkflows/local/germlinecnvcaller_cohort/main.nf
@@ -32,8 +32,8 @@ workflow GERMLINECNVCALLER_COHORT {
     GATK4_INDEXFEATUREFILE_SEGDUP(ch_segmental_duplications.filter { _meta, segdup -> !(segdup instanceof List) })
 
     // Bed to interval list conversion — only for WES when bed is provided and no interval list given
-    ch_target_bed_interval_list = channel.empty()
-    ch_exclude_bed_interval_list = channel.empty()
+    ch_target_bed_interval_list = channel.value(null)
+    ch_exclude_bed_interval_list = channel.value(null)
 
     if (val_analysis_type == "wes") {
         GATK4_BEDTOINTERVALLIST_TARGETS(
@@ -51,7 +51,7 @@ workflow GERMLINECNVCALLER_COHORT {
     }
 
     ch_user_target_interval_list
-        .combine(ch_target_bed_interval_list.ifEmpty(null))
+        .combine(ch_target_bed_interval_list)
         .branch { it ->
             intervallistfrompath: it[2].equals(null)
             return [it[0], it[1]]
@@ -66,7 +66,7 @@ workflow GERMLINECNVCALLER_COHORT {
         .set { ch_target_interval_list }
 
     ch_user_exclude_interval_list
-        .combine(ch_exclude_bed_interval_list.ifEmpty(null))
+        .combine(ch_exclude_bed_interval_list)
         .branch { it ->
             intervallistfrompath: it[2].equals(null)
             return [it[0], it[1]]

--- a/subworkflows/local/germlinecnvcaller_cohort/main.nf
+++ b/subworkflows/local/germlinecnvcaller_cohort/main.nf
@@ -14,6 +14,7 @@ workflow GERMLINECNVCALLER_COHORT {
     take:
     ch_input // channel: [mandatory] [ val(meta), path(bam/cram), path(bai/crai) ]
     val_pon_name //  string: [optional] name for panel of normals
+    val_analysis_type // string: [mandatory] type of analysis ('wes' or 'wgs')
     ch_dict // channel: [optional] [ val(meta), path(dict) ]
     ch_fai // channel: [optional] [ val(meta), path(fai) ]
     ch_fasta // channel: [mandatory] [ val(meta), path(fasta) ]
@@ -26,15 +27,26 @@ workflow GERMLINECNVCALLER_COHORT {
     ch_user_target_interval_list // channel: [optional] [ val(meta), path(intervals) ]
 
     main:
-    //  Prepare references
-    GATK4_INDEXFEATUREFILE_MAPPABILITY(ch_mappable_regions)
-    GATK4_INDEXFEATUREFILE_SEGDUP(ch_segmental_duplications)
+    //  Index feature files — only when a real file is provided
+    GATK4_INDEXFEATUREFILE_MAPPABILITY(ch_mappable_regions.filter { _meta, regions -> !(regions instanceof List) })
+    GATK4_INDEXFEATUREFILE_SEGDUP(ch_segmental_duplications.filter { _meta, segdup -> !(segdup instanceof List) })
 
-    //Runs for wes analysis, when target_bed file is provided instead of target_interval_list
-    GATK4_BEDTOINTERVALLIST_TARGETS(ch_target_bed, ch_dict)
+    // Bed to interval list conversion — only for WES when bed is provided and no interval list given
+    ch_target_bed_for_conversion = channel.of(val_analysis_type)
+        .combine(ch_user_target_interval_list.filter { _meta, interval -> interval instanceof List })
+        .combine(ch_target_bed.filter { _meta, bed -> !(bed instanceof List) })
+        .filter { analysis_type, _meta_interval, _interval, _meta_bed, _bed -> analysis_type == "wes" }
+        .map { _analysis_type, _meta_interval, _interval, meta_bed, bed -> [meta_bed, bed] }
 
-    //Runs for wes analysis, when exclude_bed file is provided instead of target_interval_list
-    GATK4_BEDTOINTERVALLIST_EXCLUDE(ch_exclude_bed, ch_dict)
+    GATK4_BEDTOINTERVALLIST_TARGETS(ch_target_bed_for_conversion, ch_dict)
+
+    ch_exclude_bed_for_conversion = channel.of(val_analysis_type)
+        .combine(ch_user_exclude_interval_list.filter { _meta, interval -> interval instanceof List })
+        .combine(ch_exclude_bed.filter { _meta, bed -> !(bed instanceof List) })
+        .filter { analysis_type, _meta_interval, _interval, _meta_bed, _bed -> analysis_type == "wes" }
+        .map { _analysis_type, _meta_interval, _interval, meta_bed, bed -> [meta_bed, bed] }
+
+    GATK4_BEDTOINTERVALLIST_EXCLUDE(ch_exclude_bed_for_conversion, ch_dict)
 
     ch_user_target_interval_list
         .combine(GATK4_BEDTOINTERVALLIST_TARGETS.out.interval_list.ifEmpty(null))

--- a/subworkflows/local/germlinecnvcaller_cohort/main.nf
+++ b/subworkflows/local/germlinecnvcaller_cohort/main.nf
@@ -32,24 +32,26 @@ workflow GERMLINECNVCALLER_COHORT {
     GATK4_INDEXFEATUREFILE_SEGDUP(ch_segmental_duplications.filter { _meta, segdup -> !(segdup instanceof List) })
 
     // Bed to interval list conversion — only for WES when bed is provided and no interval list given
-    ch_target_bed_for_conversion = channel.of(val_analysis_type)
-        .combine(ch_user_target_interval_list.filter { _meta, interval -> interval instanceof List })
-        .combine(ch_target_bed.filter { _meta, bed -> !(bed instanceof List) })
-        .filter { analysis_type, _meta_interval, _interval, _meta_bed, _bed -> analysis_type == "wes" }
-        .map { _analysis_type, _meta_interval, _interval, meta_bed, bed -> [meta_bed, bed] }
+    ch_target_bed_interval_list = channel.empty()
+    ch_exclude_bed_interval_list = channel.empty()
 
-    GATK4_BEDTOINTERVALLIST_TARGETS(ch_target_bed_for_conversion, ch_dict)
+    if (val_analysis_type == "wes") {
+        GATK4_BEDTOINTERVALLIST_TARGETS(
+            ch_target_bed.filter { _meta, bed -> !(bed instanceof List) },
+            ch_dict,
+        )
 
-    ch_exclude_bed_for_conversion = channel.of(val_analysis_type)
-        .combine(ch_user_exclude_interval_list.filter { _meta, interval -> interval instanceof List })
-        .combine(ch_exclude_bed.filter { _meta, bed -> !(bed instanceof List) })
-        .filter { analysis_type, _meta_interval, _interval, _meta_bed, _bed -> analysis_type == "wes" }
-        .map { _analysis_type, _meta_interval, _interval, meta_bed, bed -> [meta_bed, bed] }
+        GATK4_BEDTOINTERVALLIST_EXCLUDE(
+            ch_exclude_bed.filter { _meta, bed -> !(bed instanceof List) },
+            ch_dict,
+        )
 
-    GATK4_BEDTOINTERVALLIST_EXCLUDE(ch_exclude_bed_for_conversion, ch_dict)
+        ch_target_bed_interval_list = GATK4_BEDTOINTERVALLIST_TARGETS.out.interval_list
+        ch_exclude_bed_interval_list = GATK4_BEDTOINTERVALLIST_EXCLUDE.out.interval_list
+    }
 
     ch_user_target_interval_list
-        .combine(GATK4_BEDTOINTERVALLIST_TARGETS.out.interval_list.ifEmpty(null))
+        .combine(ch_target_bed_interval_list.ifEmpty(null))
         .branch { it ->
             intervallistfrompath: it[2].equals(null)
             return [it[0], it[1]]
@@ -64,7 +66,7 @@ workflow GERMLINECNVCALLER_COHORT {
         .set { ch_target_interval_list }
 
     ch_user_exclude_interval_list
-        .combine(GATK4_BEDTOINTERVALLIST_EXCLUDE.out.interval_list.ifEmpty(null))
+        .combine(ch_exclude_bed_interval_list.ifEmpty(null))
         .branch { it ->
             intervallistfrompath: it[2].equals(null)
             return [it[0], it[1]]

--- a/workflows/createpanelrefs.nf
+++ b/workflows/createpanelrefs.nf
@@ -16,6 +16,7 @@ workflow CREATEPANELREFS {
     samplesheet // channel: samplesheet read in from --input
     tools // list: tools to run
     gcnv_model_name // string: name of gcnv model
+    gcnv_analysis_type // string: type of analysis for germlinecnvcaller ('wes' or 'wgs')
     gens_analysis_type // string: type of analysis for gens pon ('lrs' or 'srs')
     gens_pon_name // string: name of gens pon
     mutect2_pon_name // string: name of mutect2 pon
@@ -79,6 +80,7 @@ workflow CREATEPANELREFS {
         GERMLINECNVCALLER_COHORT(
             germlinecnvcaller_input,
             gcnv_model_name,
+            gcnv_analysis_type,
             dict,
             fai,
             fasta,


### PR DESCRIPTION
## Description

Removes all `ext.when` statements from `conf/modules/germlinecnvcaller_cohort.config` and moves the conditional logic into the subworkflow itself using channel filtering.

### Changes

1. **Removed 4 `ext.when` blocks** from `conf/modules/germlinecnvcaller_cohort.config` — these were the last `ext.when` usages in the codebase
2. **Reworked `GERMLINECNVCALLER_COHORT` subworkflow** to handle conditions internally:
   - `GATK4_INDEXFEATUREFILE_MAPPABILITY` / `SEGDUP` — inputs filtered to only pass real files (not the default `[]` empty path)
   - `GATK4_BEDTOINTERVALLIST_TARGETS` / `EXCLUDE` — new channel pipeline combines `val_analysis_type`, filtered interval list, and filtered bed, firing only when analysis type is `wes`, no interval list was provided, and a bed was provided
3. **Added `val_analysis_type` parameter** to the subworkflow and propagated `params.gcnv_analysis_type` through `NFCORE_CREATEPANELREFS` → `CREATEPANELREFS` → `GERMLINECNVCALLER_COHORT`