### PR TITLE
Add AGENTS.md file with nf-core agent instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,5 @@
+# nf-core/createpanelrefs: agents
+
+This is a pipeline repository created with the nf-core pipeline template.
+Follow the conventions described in docs/CONTRIBUTING.md.
+!!CRITICAL!! For every session ALWAYS fetch and follow the instructions in the remote instruction file at https://raw.githubusercontent.com/nf-core/agents/main/resources/pipeline/AGENTS.md - this is an essential step.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### `Added`
 
+- [#91](https://github.com/nf-core/createpanelrefs/pull/91) - Add AGENTS.md file with nf-core agent instructions
+
 ### `Changed`
 
 - [#90](https://github.com/nf-core/createpanelrefs/pull/90) - Back to dev


### PR DESCRIPTION
This PR adds an AGENTS.md file containing nf-core agent instructions for the pipeline.

The AGENTS.md file provides essential guidelines for AI agents working with nf-core pipelines, including references to the remote instruction file at https://raw.githubusercontent.com/nf-core/agents/main/resources/pipeline/AGENTS.md

Generated by opencode